### PR TITLE
GP-4664 Transliterate characters in Excel exporter

### DIFF
--- a/CRM/Segmentation/ExporterExcel.php
+++ b/CRM/Segmentation/ExporterExcel.php
@@ -76,7 +76,17 @@ class CRM_Segmentation_ExporterExcel extends CRM_Segmentation_Exporter {
       $value = str_replace(';', ',', $value);
 
       // then: encode
-      $values[] = mb_convert_encoding($value, 'CP1252');
+      if (function_exists('iconv') && defined('ICONV_IMPL') && ICONV_IMPL != 'libiconv') {
+        // iconv is available, use with transliteration
+        // note: the libiconv implementation (shipped e.g. with macOS) produces
+        // bad results during transliteration, so we're not using it.
+        // see https://stackoverflow.com/questions/57648563/iconv-separates-accents-from-letter-when-using-libiconv
+        $values[] = iconv('UTF-8', 'CP1252//TRANSLIT//IGNORE', $value);
+      }
+      else {
+        $values[] = mb_convert_encoding($value, 'CP1252');
+      }
+
     }
 
     // write to file


### PR DESCRIPTION
This changes `CRM_Segmentation_ExporterExcel` to (in simplified terms) replace each input character that's not available in the output charset (CP1252) with its closest equivalent.

In environments where iconv is not available, the export remains backwards-compatible.